### PR TITLE
chore: set `headless: "new"` to puppeteer

### DIFF
--- a/src/plugins/mermaidRemarkPlugin.ts
+++ b/src/plugins/mermaidRemarkPlugin.ts
@@ -26,7 +26,7 @@ export const mermaidRemarkPlugin: RemarkPlugin = () => {
     }
 
     const browser = await puppeteer.launch({
-      headless: true,
+      headless: "new",
     });
 
     await Promise.all(


### PR DESCRIPTION
```
  Puppeteer old Headless deprecation warning:
    In the near feature `headless: true` will default to the new Headless mode
    for Chrome instead of the old Headless implementation. For more
    information, please see https://developer.chrome.com/articles/new-headless/.
    Consider opting in early by passing `headless: "new"` to `puppeteer.launch()`
    If you encounter any bugs, please report them to https://github.com/puppeteer/puppeteer/issues/new/choose.
```

https://developer.chrome.com/docs/chromium/new-headless?hl=ja