### PR TITLE
ci: use preview in VRT workflow

### DIFF
--- a/.github/workflows/vrt.yml
+++ b/.github/workflows/vrt.yml
@@ -18,6 +18,7 @@ jobs:
       - run: npm i
       - run: npx playwright install --with-deps
       - run: npx astro preferences disable devToolbar # hide astro dev toolbar from screen
+      - run: npm run build
       - run: npm run vrt:shot
       - uses: reg-viz/reg-actions@v2
         with:

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -37,7 +37,7 @@ export default defineConfig({
 
   /* Run your local dev server before starting the tests */
   webServer: {
-    command: "npm run dev",
+    command: process.env.CI ? "npm run preview" : "npm run dev",
     url: "http://localhost:4321",
     reuseExistingServer: !process.env.CI,
     stdout: "pipe",

--- a/tests/vrt/pages.test.ts
+++ b/tests/vrt/pages.test.ts
@@ -22,7 +22,7 @@ pages.forEach((target) => {
     await page.goto(target.path);
     await expect(page).toHaveScreenshot({
       fullPage: true,
-      timeout: 30_000,
+      timeout: 30_000, // `/s-works` の撮影に時間がかかる...
     });
   });
 });

--- a/tests/vrt/pages.test.ts
+++ b/tests/vrt/pages.test.ts
@@ -22,6 +22,7 @@ pages.forEach((target) => {
     await page.goto(target.path);
     await expect(page).toHaveScreenshot({
       fullPage: true,
+      timeout: 30_000,
     });
   });
 });


### PR DESCRIPTION
vrt で timeout になっちゃうし、そもそも screenshot は production build に対してのほうが良いよね

https://github.com/TatsuyaYamamoto/t28.dev/actions/runs/14789104841/job/41522808581